### PR TITLE
Fix build failure on OSX/macOS/BSD

### DIFF
--- a/src/bobbin-internal.h
+++ b/src/bobbin-internal.h
@@ -36,6 +36,12 @@ typedef uint8_t     byte;
 #define HI(w)           ((0xFF00 & (w)) >> 8)
 #define LO(w)           (0x00FF & (w))
 
+#if defined(__APPLE__) || defined(__NetBSD__)
+#define st_atim st_atimespec
+#define st_ctim st_ctimespec
+#define st_mtim st_mtimespec
+#endif
+
 extern void bobbin_run(void);
 extern word current_pc(void);
 


### PR DESCRIPTION
macOS and BSDs have a slightly different `timespec` you see.